### PR TITLE
7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .vagrant
+playbook.retry

--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 Using Vagrant and an official Ubuntu box designed for Virtualbox.
 
+Ansible provisioning for Vagrant.
+
+Nodejs for bot.
+
 ### Installation (Mac OS X)
 
 Install Homebrew:

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -60,11 +60,9 @@ Vagrant.configure("2") do |config|
   # View the documentation for the provider you are using for more
   # information on available options.
 
-  # Enable provisioning with a shell script. Additional provisioners such as
-  # Puppet, Chef, Ansible, Salt, and Docker are also available. Please see the
-  # documentation for more information about their specific syntax and use.
-  # config.vm.provision "shell", inline: <<-SHELL
-  #   apt-get update
-  #   apt-get install -y apache2
-  # SHELL
+  # Run Ansible from the Vagrant VM
+  # https://www.vagrantup.com/docs/provisioning/ansible_local.html
+  config.vm.provision "ansible_local" do |ansible|
+    ansible.playbook = "playbook.yml"
+  end
 end

--- a/playbook.yml
+++ b/playbook.yml
@@ -1,0 +1,2 @@
+---
+- hosts: bot-servers

--- a/playbook.yml
+++ b/playbook.yml
@@ -1,2 +1,7 @@
 ---
-- hosts: bot-servers
+- name: common configuration for all systems
+  hosts: all
+  remote_user: root
+  become: true
+  roles:
+    - geerlingguy.nodejs

--- a/roles/geerlingguy.nodejs/.gitignore
+++ b/roles/geerlingguy.nodejs/.gitignore
@@ -1,0 +1,2 @@
+*.retry
+tests/test.sh

--- a/roles/geerlingguy.nodejs/.travis.yml
+++ b/roles/geerlingguy.nodejs/.travis.yml
@@ -1,0 +1,41 @@
+---
+services: docker
+
+env:
+  # Defaults.
+  - distro: centos7
+  - distro: centos6
+  - distro: ubuntu1604
+  - distro: ubuntu1404
+  - distro: debian9
+  - distro: debian8
+
+  # Latest release.
+  - distro: centos7
+    playbook: test-latest.yml
+  - distro: ubuntu1604
+    playbook: test-latest.yml
+
+script:
+  # Configure test script so we can run extra tests after playbook is run.
+  - export container_id=$(date +%s)
+  - export cleanup=false
+
+  # Download test shim.
+  - wget -O ${PWD}/tests/test.sh https://gist.githubusercontent.com/geerlingguy/73ef1e5ee45d8694570f334be385e181/raw/
+  - chmod +x ${PWD}/tests/test.sh
+
+  # Run tests.
+  - ${PWD}/tests/test.sh
+
+  # Ensure Node.js is installed.
+  - 'docker exec --tty ${container_id} env TERM=xterm which node'
+  - 'docker exec --tty ${container_id} env TERM=xterm node -v'
+
+  # Ensure npm packages are installed globally.
+  - 'docker exec --tty ${container_id} env TERM=xterm bash --login -c "npm list -g --depth=0 jslint"'
+  - 'docker exec --tty ${container_id} env TERM=xterm bash --login -c "npm list -g --depth=0 node-sass"'
+  - 'docker exec --tty ${container_id} env TERM=xterm bash --login -c "npm list -g --depth=0 yo"'
+
+notifications:
+  webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/roles/geerlingguy.nodejs/LICENSE
+++ b/roles/geerlingguy.nodejs/LICENSE
@@ -1,0 +1,20 @@
+The MIT License (MIT)
+
+Copyright (c) 2017 Jeff Geerling
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/roles/geerlingguy.nodejs/README.md
+++ b/roles/geerlingguy.nodejs/README.md
@@ -1,0 +1,73 @@
+# Ansible Role: Node.js
+
+[![Build Status](https://travis-ci.org/geerlingguy/ansible-role-nodejs.svg?branch=master)](https://travis-ci.org/geerlingguy/ansible-role-nodejs)
+
+Installs Node.js on RHEL/CentOS or Debian/Ubuntu.
+
+## Requirements
+
+Requires the EPEL repository on RedHat/CentOS (you can install it by simply adding the `geerlingguy.repo-epel` role to your playbook).
+
+## Role Variables
+
+Available variables are listed below, along with default values (see `defaults/main.yml`):
+
+    nodejs_version: "6.x"
+
+The Node.js version to install. "6.x" is the default and works on most supported OSes. Other versions such as "0.12", "4.x", "5.x", "6.x", etc. should work on the latest versions of Debian/Ubuntu and RHEL/CentOS.
+
+    nodejs_install_npm_user: "{{ ansible_ssh_user }}"
+
+The user for whom the npm packages will be installed can be set here, this defaults to `ansible_user`.
+
+    npm_config_prefix: "/usr/local/lib/npm"
+
+The global installation directory. This should be writeable by the `nodejs_install_npm_user`.
+
+    npm_config_unsafe_perm: "false"
+
+Set to true to suppress the UID/GID switching when running package scripts. If set explicitly to false, then installing as a non-root user will fail.
+
+    nodejs_npm_global_packages: []
+
+A list of npm packages with a `name` and (optional) `version` to be installed globally. For example:
+
+    nodejs_npm_global_packages:
+      # Install a specific version of a package.
+      - name: jslint
+        version: 0.9.3
+      # Install the latest stable release of a package.
+      - name: node-sass
+      # This shorthand syntax also works (same as previous example).
+      - node-sass
+<!-- code block separator -->
+
+    nodejs_package_json_path: ""
+
+Set a path pointing to a particular `package.json` (e.g. `"/var/www/app/package.json"`). This will install all of the defined packages globally using Ansible's `npm` module.
+
+## Dependencies
+
+None.
+
+## Example Playbook
+
+    - hosts: utility
+      vars_files:
+        - vars/main.yml
+      roles:
+        - geerlingguy.nodejs
+
+*Inside `vars/main.yml`*:
+
+    nodejs_npm_global_packages:
+      - name: jslint
+      - name: node-sass
+
+## License
+
+MIT / BSD
+
+## Author Information
+
+This role was created in 2014 by [Jeff Geerling](https://www.jeffgeerling.com/), author of [Ansible for DevOps](https://www.ansiblefordevops.com/).

--- a/roles/geerlingguy.nodejs/defaults/main.yml
+++ b/roles/geerlingguy.nodejs/defaults/main.yml
@@ -1,0 +1,26 @@
+---
+# Set the version of Node.js to install ("0.12", "4.x", "5.x", "6.x", "8.x").
+# Version numbers from Nodesource: https://github.com/nodesource/distributions
+nodejs_version: "6.x"
+
+# The user for whom the npm packages will be installed.
+# nodejs_install_npm_user: username
+
+# The directory for global installations.
+npm_config_prefix: "/usr/local/lib/npm"
+
+# Set to true to suppress the UID/GID switching when running package scripts. If set explicitly to false, then installing as a non-root user will fail.
+npm_config_unsafe_perm: "false"
+
+# Define a list of global packages to be installed with NPM.
+nodejs_npm_global_packages: []
+#  # Install a specific version of a package.
+#  - name: jslint
+#    version: 0.9.3
+#  # Install the latest stable release of a package.
+#  - name: node-sass
+#  # This shorthand syntax also works (same as previous example).
+#  - node-sass
+
+# The path of a package.json file used to install packages globally.
+nodejs_package_json_path: ""

--- a/roles/geerlingguy.nodejs/meta/.galaxy_install_info
+++ b/roles/geerlingguy.nodejs/meta/.galaxy_install_info
@@ -1,0 +1,1 @@
+{install_date: 'Wed Oct  4 06:31:01 2017', version: 4.1.2}

--- a/roles/geerlingguy.nodejs/meta/main.yml
+++ b/roles/geerlingguy.nodejs/meta/main.yml
@@ -1,0 +1,24 @@
+---
+dependencies: []
+
+galaxy_info:
+  author: geerlingguy
+  description: Node.js installation for Linux
+  company: "Midwestern Mac, LLC"
+  license: "license (BSD, MIT)"
+  min_ansible_version: 1.9
+  platforms:
+    - name: EL
+      versions:
+      - 6
+      - 7
+    - name: Debian
+      versions:
+      - all
+    - name: Ubuntu
+      versions:
+      - trusty
+      - xenial
+  galaxy_tags:
+    - development
+    - web

--- a/roles/geerlingguy.nodejs/tasks/main.yml
+++ b/roles/geerlingguy.nodejs/tasks/main.yml
@@ -1,0 +1,41 @@
+---
+- include: setup-RedHat.yml
+  when: ansible_os_family == 'RedHat'
+
+- include: setup-Debian.yml
+  when: ansible_os_family == 'Debian'
+
+- name: Define nodejs_install_npm_user
+  set_fact:
+    nodejs_install_npm_user: "{{ ansible_user | default(lookup('env', 'USER')) }}"
+  when: nodejs_install_npm_user is not defined
+
+- name: Create npm global directory
+  file:
+    path: "{{ npm_config_prefix }}"
+    owner: "{{ nodejs_install_npm_user }}"
+    group: "{{ nodejs_install_npm_user }}"
+    state: directory
+
+- name: Add npm_config_prefix bin directory to global $PATH.
+  template:
+    src: npm.sh.j2
+    dest: /etc/profile.d/npm.sh
+    mode: 0644
+
+- name: Ensure npm global packages are installed.
+  npm:
+    name: "{{ item.name | default(item) }}"
+    version: "{{ item.version | default('latest') }}"
+    global: yes
+    state: latest
+  environment:
+    NPM_CONFIG_PREFIX: "{{ npm_config_prefix }}"
+    NODE_PATH: "{{ npm_config_prefix }}/lib/node_modules"
+    NPM_CONFIG_UNSAFE_PERM: "{{ npm_config_unsafe_perm }}"
+  with_items: "{{ nodejs_npm_global_packages }}"
+
+- name: Install packages defined in a given package.json.
+  npm:
+    path: "{{ nodejs_package_json_path }}"
+  when: nodejs_package_json_path is defined and nodejs_package_json_path

--- a/roles/geerlingguy.nodejs/tasks/setup-Debian.yml
+++ b/roles/geerlingguy.nodejs/tasks/setup-Debian.yml
@@ -1,0 +1,25 @@
+---
+- name: Ensure apt-transport-https is installed.
+  apt: name=apt-transport-https state=present
+
+- name: Add Nodesource apt key.
+  apt_key:
+    url: https://keyserver.ubuntu.com/pks/lookup?op=get&fingerprint=on&search=0x1655A0AB68576280
+    id: "68576280"
+    state: present
+
+- name: Add NodeSource repositories for Node.js.
+  apt_repository:
+    repo: "{{ item }}"
+    state: present
+  with_items:
+    - "deb https://deb.nodesource.com/node_{{ nodejs_version }} {{ ansible_distribution_release }} main"
+    - "deb-src https://deb.nodesource.com/node_{{ nodejs_version }} {{ ansible_distribution_release }} main"
+  register: node_repo
+
+- name: Update apt cache if repo was added.
+  apt: update_cache=yes
+  when: node_repo.changed
+
+- name: Ensure Node.js and npm are installed.
+  apt: "name=nodejs={{ nodejs_version|regex_replace('x', '') }}* state=present"

--- a/roles/geerlingguy.nodejs/tasks/setup-RedHat.yml
+++ b/roles/geerlingguy.nodejs/tasks/setup-RedHat.yml
@@ -1,0 +1,37 @@
+---
+- name: Set up the Nodesource RPM directory for Node.js > 0.10.
+  set_fact:
+    nodejs_rhel_rpm_dir: "pub_{{ nodejs_version }}"
+  when: nodejs_version != '0.10'
+
+- name: Set up the Nodesource RPM variable for Node.js == 0.10.
+  set_fact:
+    nodejs_rhel_rpm_dir: "pub"
+  when: nodejs_version == '0.10'
+
+- name: Import Nodesource RPM key (CentOS < 7).
+  rpm_key:
+    key: http://rpm.nodesource.com/pub/el/NODESOURCE-GPG-SIGNING-KEY-EL
+    state: present
+  when: ansible_distribution_major_version|int < 7
+
+- name: Import Nodesource RPM key (CentOS 7+)..
+  rpm_key:
+    key: https://rpm.nodesource.com/pub/el/NODESOURCE-GPG-SIGNING-KEY-EL
+    state: present
+  when: ansible_distribution_major_version|int >= 7
+
+- name: Add Nodesource repositories for Node.js (CentOS < 7).
+  yum:
+    name: "http://rpm.nodesource.com/{{ nodejs_rhel_rpm_dir }}/el/{{ ansible_distribution_major_version }}/{{ ansible_architecture }}/nodesource-release-el{{ ansible_distribution_major_version }}-1.noarch.rpm"
+    state: present
+  when: ansible_distribution_major_version|int < 7
+
+- name: Add Nodesource repositories for Node.js (CentOS 7+).
+  yum:
+    name: "https://rpm.nodesource.com/{{ nodejs_rhel_rpm_dir }}/el/{{ ansible_distribution_major_version }}/{{ ansible_architecture }}/nodesource-release-el{{ ansible_distribution_major_version }}-1.noarch.rpm"
+    state: present
+  when: ansible_distribution_major_version|int >= 7
+
+- name: Ensure Node.js and npm are installed.
+  yum: "name=nodejs-{{ nodejs_version[0] }}.* state=present enablerepo='epel,nodesource'"

--- a/roles/geerlingguy.nodejs/templates/npm.sh.j2
+++ b/roles/geerlingguy.nodejs/templates/npm.sh.j2
@@ -1,0 +1,3 @@
+export PATH={{ npm_config_prefix }}/bin:$PATH
+export NPM_CONFIG_PREFIX={{ npm_config_prefix }}
+export NODE_PATH=$NODE_PATH:{{ npm_config_prefix }}/lib/node_modules

--- a/roles/geerlingguy.nodejs/tests/README.md
+++ b/roles/geerlingguy.nodejs/tests/README.md
@@ -1,0 +1,11 @@
+# Ansible Role tests
+
+To run the test playbook(s) in this directory:
+
+  1. Install and start Docker.
+  1. Download the test shim (see .travis.yml file for the URL) into `tests/test.sh`:
+    - `wget -O tests/test.sh https://gist.githubusercontent.com/geerlingguy/73ef1e5ee45d8694570f334be385e181/raw/`
+  1. Make the test shim executable: `chmod +x tests/test.sh`.
+  1. Run (from the role root directory) `distro=[distro] playbook=[playbook] ./tests/test.sh`
+
+If you don't want the container to be automatically deleted after the test playbook is run, add the following environment variables: `cleanup=false container_id=$(date +%s)`

--- a/roles/geerlingguy.nodejs/tests/test-latest.yml
+++ b/roles/geerlingguy.nodejs/tests/test-latest.yml
@@ -1,0 +1,21 @@
+---
+- hosts: all
+
+  vars:
+    nodejs_version: "8.x"
+    nodejs_install_npm_user: root
+    npm_config_prefix: /root/.npm-global
+    npm_config_unsafe_perm: "true"
+    nodejs_npm_global_packages:
+      - node-sass
+      - name: jslint
+        version: 0.9.6
+      - name: yo
+
+  pre_tasks:
+    - name: Update apt cache.
+      apt: update_cache=yes cache_valid_time=600
+      when: ansible_os_family == 'Debian'
+
+  roles:
+    - role_under_test

--- a/roles/geerlingguy.nodejs/tests/test.yml
+++ b/roles/geerlingguy.nodejs/tests/test.yml
@@ -1,0 +1,20 @@
+---
+- hosts: all
+
+  vars:
+    nodejs_install_npm_user: root
+    npm_config_prefix: /root/.npm-global
+    npm_config_unsafe_perm: "true"
+    nodejs_npm_global_packages:
+      - node-sass
+      - name: jslint
+        version: 0.9.6
+      - name: yo
+
+  pre_tasks:
+    - name: Update apt cache.
+      apt: update_cache=yes cache_valid_time=600
+      when: ansible_os_family == 'Debian'
+
+  roles:
+    - role_under_test


### PR DESCRIPTION
fixes #7 
fixes #3 

testing:
- run `vagrant up` or `vagrant provision` if vagrant is already up
- check that ansible runs and installs nodejs
- run `vagrant ssh -c npm` and check to see default npm help text