### PR TITLE
add mysql to ansible

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,13 @@ Install Vagrant and Virtualbox:
 Build and launch local dev environment:
 
 `vagrant up`
+
+### Ansible
+
+Downloading new roles is done through vagrant (unless you have Ansible installed on the host).
+
+`vagrant ssh -c "ansible-galaxy install --roles-path /vagrant/roles username.role"`
+
+Where `username.role` is as per https://galaxy.ansible.com/
+
+This will download to the roles directory shared between the vagrant guest and the repo on the host.

--- a/playbook.yml
+++ b/playbook.yml
@@ -5,3 +5,4 @@
   become: true
   roles:
     - geerlingguy.nodejs
+    - geerlingguy.mysql

--- a/roles/geerlingguy.mysql/.gitignore
+++ b/roles/geerlingguy.mysql/.gitignore
@@ -1,0 +1,2 @@
+*.retry
+tests/test.sh

--- a/roles/geerlingguy.mysql/.travis.yml
+++ b/roles/geerlingguy.mysql/.travis.yml
@@ -1,0 +1,54 @@
+---
+services: docker
+
+env:
+  - distro: centos7
+    playbook: centos-7-test.yml
+  - distro: centos6
+    playbook: test.yml
+  - distro: debian8
+    playbook: test.yml
+  - distro: ubuntu1604
+    playbook: test.yml
+  - distro: ubuntu1404
+    playbook: test.yml
+
+script:
+  # Configure test script so we can run extra tests after playbook is run.
+  - export container_id=$(date +%s)
+  - export cleanup=false
+
+  # Download test shim.
+  - wget -O ${PWD}/tests/test.sh https://gist.githubusercontent.com/geerlingguy/73ef1e5ee45d8694570f334be385e181/raw/
+  - chmod +x ${PWD}/tests/test.sh
+
+  # Run tests.
+  - ${PWD}/tests/test.sh
+
+  # Some MySQL debugging (show all the logs).
+  - docker exec --tty ${container_id} env TERM=xterm ls -lah /var/log
+  - docker exec --tty ${container_id} env TERM=xterm cat /var/log/mysql/error.log || true
+  - docker exec --tty ${container_id} env TERM=xterm cat /var/log/mysql.err || true
+
+  # Check to make sure we can connect to MySQL via Unix socket.
+  - >
+    sudo docker exec ${container_id} mysql -u root -proot -e 'show databases;'
+    | grep -q 'information_schema'
+    && (echo 'MySQL running normally' && exit 0)
+    || (echo 'MySQL not running' && exit 1)
+
+  # Check to make sure we can connect to MySQL via TCP.
+  - >
+    sudo docker exec ${container_id} mysql -u root -proot -h 127.0.0.1 -e 'show databases;'
+    | grep -q 'information_schema'
+    && (echo 'MySQL running normally' && exit 0)
+    || (echo 'MySQL not running' && exit 1)
+
+after_failure:
+  # Check MySQL settings.
+  - 'docker exec --tty ${container_id} env TERM=xterm cat /var/log/mysql/error.log'
+  - 'docker exec --tty ${container_id} env TERM=xterm cat /var/log/mysql.err'
+  - 'docker exec --tty ${container_id} env TERM=xterm cat /var/log/mysql.log'
+
+notifications:
+  webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/roles/geerlingguy.mysql/LICENSE
+++ b/roles/geerlingguy.mysql/LICENSE
@@ -1,0 +1,20 @@
+The MIT License (MIT)
+
+Copyright (c) 2017 Jeff Geerling
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/roles/geerlingguy.mysql/README.md
+++ b/roles/geerlingguy.mysql/README.md
@@ -1,0 +1,190 @@
+# Ansible Role: MySQL
+
+[![Build Status](https://travis-ci.org/geerlingguy/ansible-role-mysql.svg?branch=master)](https://travis-ci.org/geerlingguy/ansible-role-mysql)
+
+Installs and configures MySQL or MariaDB server on RHEL/CentOS or Debian/Ubuntu servers.
+
+## Requirements
+
+No special requirements; note that this role requires root access, so either run it in a playbook with a global `become: yes`, or invoke the role in your playbook like:
+
+    - hosts: database
+      roles:
+        - role: geerlingguy.mysql
+          become: yes
+
+## Role Variables
+
+Available variables are listed below, along with default values (see `defaults/main.yml`):
+
+    mysql_user_home: /root
+    mysql_user_name: root
+    mysql_user_password: root
+
+The home directory inside which Python MySQL settings will be stored, which Ansible will use when connecting to MySQL. This should be the home directory of the user which runs this Ansible role. The `mysql_user_name` and `mysql_user_password` can be set if you are running this role under a non-root user account and want to set a non-root user.
+
+    mysql_root_home: /root
+    mysql_root_username: root
+    mysql_root_password: root
+
+The MySQL root user account details.
+
+    mysql_root_password_update: no
+
+Whether to force update the MySQL root user's password. By default, this role will only change the root user's password when MySQL is first configured. You can force an update by setting this to `yes`.
+
+> Note: If you get an error like `ERROR 1045 (28000): Access denied for user 'root'@'localhost' (using password: YES)` after a failed or interrupted playbook run, this usually means the root password wasn't originally updated to begin with. Try either removing  the `.my.cnf` file inside the configured `mysql_user_home` or updating it and setting `password=''` (the insecure default password). Run the playbook again, with `mysql_root_password_update` set to `yes`, and the setup should complete.
+
+> Note: If you get an error like `ERROR 1698 (28000): Access denied for user 'root'@'localhost' (using password: YES)` when trying to log in from the CLI you might need to run as root or sudoer.
+
+    mysql_enabled_on_startup: yes
+
+Whether MySQL should be enabled on startup.
+
+    mysql_config_file: *default value depends on OS*
+    mysql_config_include_dir: *default value depends on OS*
+    
+The main my.cnf configuration file and include directory.
+
+    overwrite_global_mycnf: yes
+
+Whether the global my.cnf should be overwritten each time this role is run. Setting this to `no` tells Ansible to only create the `my.cnf` file if it doesn't exist. This should be left at its default value (`yes`) if you'd like to use this role's variables to configure MySQL.
+
+    mysql_config_include_files: []
+
+A list of files that should override the default global my.cnf. Each item in the array requires a "src" parameter which is a path to a file. An optional "force" parameter can force the file to be updated each time ansible runs.
+
+    mysql_databases: []
+
+The MySQL databases to create. A database has the values `name`, `encoding` (defaults to `utf8`), `collation` (defaults to `utf8_general_ci`) and `replicate` (defaults to `1`, only used if replication is configured). The formats of these are the same as in the `mysql_db` module.
+
+    mysql_users: []
+
+The MySQL users and their privileges. A user has the values:
+
+  - `name`
+  - `host` (defaults to `localhost`)
+  - `password` (can be plaintext or encrypted—if encrypted, set `encrypted: yes`)
+  - `encrypted` (defaults to `no`)
+  - `priv` (defaults to `*.*:USAGE`)
+  - `append_privs` (defaults to `no`)
+  - `state`  (defaults to `present`)
+
+The formats of these are the same as in the `mysql_user` module.
+
+    mysql_packages:
+      - mysql
+      - mysql-server
+
+(OS-specific, RedHat/CentOS defaults listed here) Packages to be installed. In some situations, you may need to add additional packages, like `mysql-devel`.
+
+    mysql_enablerepo: ""
+
+(RedHat/CentOS only) If you have enabled any additional repositories (might I suggest geerlingguy.repo-epel or geerlingguy.repo-remi), those repositories can be listed under this variable (e.g. `remi,epel`). This can be handy, as an example, if you want to install later versions of MySQL.
+
+    mysql_port: "3306"
+    mysql_bind_address: '0.0.0.0'
+    mysql_datadir: /var/lib/mysql
+    mysql_socket: *default value depends on OS*
+    mysql_pid_file: *default value depends on OS*
+
+Default MySQL connection configuration.
+
+    mysql_log: ""
+    mysql_log_error: *default value depends on OS*
+    mysql_syslog_tag: *default value depends on OS*
+
+MySQL logging configuration. Setting `mysql_log` (the general query log) or `mysql_log_error` to `syslog` will make MySQL log to syslog using the `mysql_syslog_tag`.
+
+    mysql_slow_query_log_enabled: no
+    mysql_slow_query_log_file: *default value depends on OS*
+    mysql_slow_query_time: 2
+
+Slow query log settings. Note that the log file will be created by this role, but if you're running on a server with SELinux or AppArmor, you may need to add this path to the allowed paths for MySQL, or disable the mysql profile. For example, on Debian/Ubuntu, you can run `sudo ln -s /etc/apparmor.d/usr.sbin.mysqld /etc/apparmor.d/disable/usr.sbin.mysqld && sudo service apparmor restart`.
+
+    mysql_key_buffer_size: "256M"
+    mysql_max_allowed_packet: "64M"
+    mysql_table_open_cache: "256"
+    [...]
+
+The rest of the settings in `defaults/main.yml` control MySQL's memory usage and some other common settings. The default values are tuned for a server where MySQL can consume ~512 MB RAM, so you should consider adjusting them to suit your particular server better.
+
+    mysql_server_id: "1"
+    mysql_max_binlog_size: "100M"
+    mysql_binlog_format: "ROW"
+    mysql_expire_logs_days: "10"
+    mysql_replication_role: ''
+    mysql_replication_master: ''
+    mysql_replication_user: []
+
+Replication settings. Set `mysql_server_id` and `mysql_replication_role` by server (e.g. the master would be ID `1`, with the `mysql_replication_role` of `master`, and the slave would be ID `2`, with the `mysql_replication_role` of `slave`). The `mysql_replication_user` uses the same keys as `mysql_users`, and is created on master servers, and used to replicate on all the slaves.
+
+### Later versions of MySQL on CentOS 7
+
+If you want to install MySQL from the official repository instead of installing the system default MariaDB equivalents, you can add the following `pre_tasks` task in your playbook:
+
+```yaml
+  pre_tasks:
+    - name: Install the MySQL repo.
+      yum:
+        name: http://repo.mysql.com/mysql-community-release-el7-5.noarch.rpm
+        state: present
+      when: ansible_os_family == "RedHat"
+  
+    - name: Override variables for MySQL (RedHat).
+      set_fact:
+        mysql_daemon: mysqld
+        mysql_packages: ['mysql-server']
+        mysql_log_error: /var/log/mysqld.err
+        mysql_syslog_tag: mysqld
+        mysql_pid_file: /var/run/mysqld/mysqld.pid
+        mysql_socket: /var/lib/mysql/mysql.sock
+      when: ansible_os_family == "RedHat"
+```
+
+### MariaDB usage
+
+This role works with either MySQL or a compatible version of MariaDB. On RHEL/CentOS 7+, the mariadb database engine was substituted as the default MySQL replacement package. No modifications are necessary though all of the variables still reference 'mysql' instead of mariadb.
+
+#### Ubuntu 14.04 and 16.04 MariaDB configuration
+
+On Ubuntu, the package names are named differently, so the `mysql_package` variable needs to be altered. Set the following variables (at a minimum):
+
+    mysql_packages:
+      - mariadb-client
+      - mariadb-server
+      - python-mysqldb
+
+## Dependencies
+
+None.
+
+## Example Playbook
+
+    - hosts: db-servers
+      become: yes
+      vars_files:
+        - vars/main.yml
+      roles:
+        - { role: geerlingguy.mysql }
+
+*Inside `vars/main.yml`*:
+
+    mysql_root_password: super-secure-password
+    mysql_databases:
+      - name: example_db
+        encoding: latin1
+        collation: latin1_general_ci
+    mysql_users:
+      - name: example_user
+        host: "%"
+        password: similarly-secure-password
+        priv: "example_db.*:ALL"
+
+## License
+
+MIT / BSD
+
+## Author Information
+
+This role was created in 2014 by [Jeff Geerling](https://www.jeffgeerling.com/), author of [Ansible for DevOps](https://www.ansiblefordevops.com/).

--- a/roles/geerlingguy.mysql/defaults/main.yml
+++ b/roles/geerlingguy.mysql/defaults/main.yml
@@ -1,0 +1,125 @@
+---
+# Set this to the user ansible is logging in as - should have root
+# or sudo access
+mysql_user_home: /root
+mysql_user_name: root
+mysql_user_password: root
+
+# The default root user installed by mysql - almost always root
+mysql_root_home: /root
+mysql_root_username: root
+mysql_root_password: root
+
+# Set this to `yes` to forcibly update the root password.
+mysql_root_password_update: no
+mysql_user_password_update: no
+
+mysql_enabled_on_startup: yes
+
+# update my.cnf. each time role is run? yes | no
+overwrite_global_mycnf: yes
+
+# The following variables have a default value depending on operating system.
+# mysql_config_file: /etc/my.cnf
+# mysql_config_include_dir: /etc/my.cnf.d
+
+# Pass in a comma-separated list of repos to use (e.g. "remi,epel"). Used only
+# for RedHat systems (and derivatives).
+mysql_enablerepo: ""
+
+# Define a custom list of packages to install; if none provided, the default
+# package list from vars/[OS-family].yml will be used.
+# mysql_packages:
+#   - mysql
+#   - mysql-server
+#   - MySQL-python
+
+# MySQL connection settings.
+mysql_port: "3306"
+mysql_bind_address: '0.0.0.0'
+mysql_skip_name_resolve: no
+mysql_datadir: /var/lib/mysql
+mysql_sql_mode: ''
+# The following variables have a default value depending on operating system.
+# mysql_pid_file: /var/run/mysqld/mysqld.pid
+# mysql_socket: /var/lib/mysql/mysql.sock
+
+# Slow query log settings.
+mysql_slow_query_log_enabled: no
+mysql_slow_query_time: "2"
+# The following variable has a default value depending on operating system.
+# mysql_slow_query_log_file: /var/log/mysql-slow.log
+
+# Memory settings (default values optimized ~512MB RAM).
+mysql_key_buffer_size: "256M"
+mysql_max_allowed_packet: "64M"
+mysql_table_open_cache: "256"
+mysql_sort_buffer_size: "1M"
+mysql_read_buffer_size: "1M"
+mysql_read_rnd_buffer_size: "4M"
+mysql_myisam_sort_buffer_size: "64M"
+mysql_thread_cache_size: "8"
+mysql_query_cache_type: "0"
+mysql_query_cache_size: "16M"
+mysql_query_cache_limit: "1M"
+mysql_max_connections: "151"
+mysql_tmp_table_size: "16M"
+mysql_max_heap_table_size: "16M"
+mysql_group_concat_max_len: "1024"
+mysql_join_buffer_size: "262144"
+
+# Other settings.
+mysql_lower_case_table_names: "0"
+mysql_wait_timeout: "28800"
+mysql_event_scheduler_state: "OFF"
+
+# InnoDB settings.
+mysql_innodb_file_per_table: "1"
+# Set .._buffer_pool_size up to 80% of RAM but beware of setting too high.
+mysql_innodb_buffer_pool_size: "256M"
+# Set .._log_file_size to 25% of buffer pool size.
+mysql_innodb_log_file_size: "64M"
+mysql_innodb_log_buffer_size: "8M"
+mysql_innodb_flush_log_at_trx_commit: "1"
+mysql_innodb_lock_wait_timeout: "50"
+
+# These settings require MySQL > 5.5.
+mysql_innodb_large_prefix: "1"
+mysql_innodb_file_format: "barracuda"
+
+# mysqldump settings.
+mysql_mysqldump_max_allowed_packet: "64M"
+
+# Logging settings.
+mysql_log: ""
+# The following variables have a default value depending on operating system.
+# mysql_log_error: /var/log/mysql/mysql.err
+# mysql_syslog_tag: mysql
+
+mysql_config_include_files: []
+#  - src: path/relative/to/playbook/file.cnf
+#  - { src: path/relative/to/playbook/anotherfile.cnf, force: yes }
+
+# Databases.
+mysql_databases: []
+#   - name: example
+#     collation: utf8_general_ci
+#     encoding: utf8
+#     replicate: 1
+
+# Users.
+mysql_users: []
+#   - name: example
+#     host: 127.0.0.1
+#     password: secret
+#     priv: *.*:USAGE
+
+# Replication settings (replication is only enabled if master/user have values).
+mysql_server_id: "1"
+mysql_max_binlog_size: "100M"
+mysql_binlog_format: "ROW"
+mysql_expire_logs_days: "10"
+mysql_replication_role: ''
+mysql_replication_master: ''
+# Same keys as `mysql_users` above.
+mysql_replication_user: []

--- a/roles/geerlingguy.mysql/handlers/main.yml
+++ b/roles/geerlingguy.mysql/handlers/main.yml
@@ -1,0 +1,3 @@
+---
+- name: restart mysql
+  service: "name={{ mysql_daemon }} state=restarted sleep=5"

--- a/roles/geerlingguy.mysql/meta/.galaxy_install_info
+++ b/roles/geerlingguy.mysql/meta/.galaxy_install_info
@@ -1,0 +1,1 @@
+{install_date: 'Wed Oct  4 07:15:34 2017', version: 2.8.0}

--- a/roles/geerlingguy.mysql/meta/main.yml
+++ b/roles/geerlingguy.mysql/meta/main.yml
@@ -1,0 +1,25 @@
+---
+dependencies: []
+
+galaxy_info:
+  author: geerlingguy
+  description: MySQL server for RHEL/CentOS and Debian/Ubuntu.
+  company: "Midwestern Mac, LLC"
+  license: "license (BSD, MIT)"
+  min_ansible_version: 2.2
+  platforms:
+    - name: EL
+      versions:
+      - 6
+      - 7
+    - name: Ubuntu
+      versions:
+      - all
+    - name: Debian
+      versions:
+      - all
+    - name: Archlinux
+      versions:
+      - all
+  galaxy_tags:
+    - database

--- a/roles/geerlingguy.mysql/tasks/configure.yml
+++ b/roles/geerlingguy.mysql/tasks/configure.yml
@@ -1,0 +1,75 @@
+---
+- name: Copy my.cnf global MySQL configuration.
+  template:
+    src: my.cnf.j2
+    dest: "{{ mysql_config_file }}"
+    owner: root
+    group: root
+    mode: 0644
+    force: "{{ overwrite_global_mycnf }}"
+  notify: restart mysql
+
+- name: Verify mysql include directory exists.
+  file:
+    path: "{{ mysql_config_include_dir }}"
+    state: directory
+    owner: root
+    group: root
+    mode: 0755
+  when: mysql_config_include_files | length
+
+- name: Copy my.cnf override files into include directory.
+  template:
+    src: "{{ item.src }}"
+    dest: "{{ mysql_config_include_dir }}/{{ item.src | basename }}"
+    owner: root
+    group: root
+    mode: 0644
+    force: "{{ item.force | default(False) }}"
+  with_items: "{{ mysql_config_include_files }}"
+  notify: restart mysql
+
+- name: Create slow query log file (if configured).
+  command: "touch {{ mysql_slow_query_log_file }}"
+  args:
+    creates: "{{ mysql_slow_query_log_file }}"
+    warn: no
+  when: mysql_slow_query_log_enabled
+
+- name: Create datadir if it does not exist
+  file:
+    path: "{{ mysql_datadir }}"
+    state: directory
+    owner: mysql
+    group: mysql
+    mode:  0755
+    setype: mysqld_db_t
+
+- name: Set ownership on slow query log file (if configured).
+  file:
+    path: "{{ mysql_slow_query_log_file }}"
+    state: file
+    owner: mysql
+    group: mysql
+    mode: 0640
+  when: mysql_slow_query_log_enabled
+
+- name: Create error log file (if configured).
+  command: "touch {{ mysql_log_error }}"
+  args:
+    creates: "{{ mysql_log_error }}"
+    warn: no
+  when: mysql_log == "" and mysql_log_error != ""
+
+- name: Set ownership on error log file (if configured).
+  file:
+    path: "{{ mysql_log_error }}"
+    state: file
+    owner: mysql
+    group: mysql
+    mode: 0640
+  when: mysql_log == "" and mysql_log_error != ""
+
+- name: Ensure MySQL is started and enabled on boot.
+  service: "name={{ mysql_daemon }} state=started enabled={{ mysql_enabled_on_startup }}"
+  register: mysql_service_configuration

--- a/roles/geerlingguy.mysql/tasks/databases.yml
+++ b/roles/geerlingguy.mysql/tasks/databases.yml
@@ -1,0 +1,8 @@
+---
+- name: Ensure MySQL databases are present.
+  mysql_db:
+    name: "{{ item.name }}"
+    collation: "{{ item.collation | default('utf8_general_ci') }}"
+    encoding: "{{ item.encoding | default('utf8') }}"
+    state: present
+  with_items: "{{ mysql_databases }}"

--- a/roles/geerlingguy.mysql/tasks/main.yml
+++ b/roles/geerlingguy.mysql/tasks/main.yml
@@ -1,0 +1,29 @@
+---
+# Variable configuration.
+- include: variables.yml
+
+# Setup/install tasks.
+- include: setup-RedHat.yml
+  when: ansible_os_family == 'RedHat'
+  static: no
+
+- include: setup-Debian.yml
+  when: ansible_os_family == 'Debian'
+  static: no
+
+- include: setup-Archlinux.yml
+  when: ansible_os_family == 'Archlinux'
+  static: no
+
+- name: Check if MySQL packages were installed.
+  set_fact:
+    mysql_install_packages: "{{ (rh_mysql_install_packages is defined and rh_mysql_install_packages.changed)
+      or (deb_mysql_install_packages is defined and deb_mysql_install_packages.changed)
+      or (arch_mysql_install_packages is defined and arch_mysql_install_packages.changed) }}"
+
+# Configure MySQL.
+- include: configure.yml
+- include: secure-installation.yml
+- include: databases.yml
+- include: users.yml
+- include: replication.yml

--- a/roles/geerlingguy.mysql/tasks/replication.yml
+++ b/roles/geerlingguy.mysql/tasks/replication.yml
@@ -1,0 +1,54 @@
+---
+- name: Ensure replication user exists on master.
+  mysql_user:
+    name: "{{ mysql_replication_user.name }}"
+    host: "{{ mysql_replication_user.host | default('%') }}"
+    password: "{{ mysql_replication_user.password }}"
+    priv: "{{ mysql_replication_user.priv | default('*.*:REPLICATION SLAVE,REPLICATION CLIENT') }}"
+    state: present
+  when: >
+    (mysql_replication_role == 'master')
+    and mysql_replication_user
+    and (mysql_replication_master != '')
+
+- name: Check slave replication status.
+  mysql_replication:
+    mode: getslave
+    login_user: "{{ mysql_replication_user.name }}"
+    login_password: "{{ mysql_replication_user.password }}"
+  ignore_errors: true
+  register: slave
+  when: >
+    mysql_replication_role == 'slave'
+    and (mysql_replication_master != '')
+
+- name: Check master replication status.
+  mysql_replication: mode=getmaster
+  delegate_to: "{{ mysql_replication_master }}"
+  register: master
+  when: >
+    ((slave.Is_Slave is defined and not slave.Is_Slave) or (slave.Is_Slave is not defined and slave|failed))
+    and (mysql_replication_role == 'slave')
+    and (mysql_replication_master != '')
+
+- name: Configure replication on the slave.
+  mysql_replication:
+    mode: changemaster
+    master_host: "{{ mysql_replication_master }}"
+    master_user: "{{ mysql_replication_user.name }}"
+    master_password: "{{ mysql_replication_user.password }}"
+    master_log_file: "{{ master.File }}"
+    master_log_pos: "{{ master.Position }}"
+  ignore_errors: True
+  when: >
+    ((slave.Is_Slave is defined and not slave.Is_Slave) or (slave.Is_Slave is not defined and slave|failed))
+    and (mysql_replication_role == 'slave')
+    and (mysql_replication_master != '')
+    and mysql_replication_user
+
+- name: Start replication.
+  mysql_replication: mode=startslave
+  when: >
+    ((slave.Is_Slave is defined and not slave.Is_Slave) or (slave.Is_Slave is not defined and slave|failed))
+    and (mysql_replication_role == 'slave')
+    and (mysql_replication_master != '')

--- a/roles/geerlingguy.mysql/tasks/secure-installation.yml
+++ b/roles/geerlingguy.mysql/tasks/secure-installation.yml
@@ -1,0 +1,80 @@
+---
+- name: Get MySQL version.
+  command: 'mysql --version'
+  register: mysql_cli_version
+  changed_when: false
+
+- name: Ensure default user is present.
+  mysql_user:
+    name: "{{ mysql_user_name }}"
+    host: 'localhost'
+    password: "{{ mysql_user_password }}"
+    priv: '*.*:ALL,GRANT'
+    state: present
+  when: mysql_user_name != mysql_root_username
+
+# Has to be after the password assignment, for idempotency.
+- name: Copy user-my.cnf file with password credentials.
+  template:
+    src: "user-my.cnf.j2"
+    dest: "{{ mysql_user_home }}/.my.cnf"
+    owner: "{{ mysql_user_name }}"
+    mode: 0600
+  when: mysql_user_name != mysql_root_username and (mysql_install_packages | bool or mysql_user_password_update)
+
+- name: Disallow root login remotely
+  command: 'mysql -NBe "{{ item }}"'
+  with_items:
+    - DELETE FROM mysql.user WHERE User='{{ mysql_root_username }}' AND Host NOT IN ('localhost', '127.0.0.1', '::1')
+  changed_when: false
+
+- name: Get list of hosts for the root user.
+  command: mysql -NBe "SELECT Host FROM mysql.user WHERE User = '{{ mysql_root_username }}' ORDER BY (Host='localhost') ASC"
+  register: mysql_root_hosts
+  changed_when: false
+  check_mode: no
+  when: mysql_install_packages | bool or mysql_root_password_update
+
+# Note: We do not use mysql_user for this operation, as it doesn't always update
+# the root password correctly. See: https://goo.gl/MSOejW
+# Set root password for MySQL >= 5.7.x.
+- name: Update MySQL root password for localhost root account (5.7.x).
+  shell: >
+    mysql -u root -NBe
+    'ALTER USER "{{ mysql_root_username }}"@"{{ item }}" IDENTIFIED WITH mysql_native_password BY "{{ mysql_root_password }}";'
+  with_items: "{{ mysql_root_hosts.stdout_lines|default([]) }}"
+  when: ((mysql_install_packages | bool) or mysql_root_password_update) and ('5.7.' in mysql_cli_version.stdout)
+
+# Set root password for MySQL < 5.7.x.
+- name: Update MySQL root password for localhost root account (< 5.7.x).
+  shell: >
+    mysql -NBe
+    'SET PASSWORD FOR "{{ mysql_root_username }}"@"{{ item }}" = PASSWORD("{{ mysql_root_password }}");'
+  with_items: "{{ mysql_root_hosts.stdout_lines|default([]) }}"
+  when: ((mysql_install_packages | bool) or mysql_root_password_update) and ('5.7.' not in mysql_cli_version.stdout)
+
+# Has to be after the root password assignment, for idempotency.
+- name: Copy .my.cnf file with root password credentials.
+  template:
+    src: "root-my.cnf.j2"
+    dest: "{{ mysql_root_home }}/.my.cnf"
+    owner: root
+    group: root
+    mode: 0600
+  when: mysql_install_packages | bool or mysql_root_password_update
+
+- name: Get list of hosts for the anonymous user.
+  command: mysql -NBe 'SELECT Host FROM mysql.user WHERE User = ""'
+  register: mysql_anonymous_hosts
+  changed_when: false
+  check_mode: no
+
+- name: Remove anonymous MySQL users.
+  mysql_user:
+     name: ""
+     host: "{{ item }}"
+     state: absent
+  with_items: "{{ mysql_anonymous_hosts.stdout_lines|default([]) }}"
+
+- name: Remove MySQL test database.
+  mysql_db: "name='test' state=absent"

--- a/roles/geerlingguy.mysql/tasks/setup-Archlinux.yml
+++ b/roles/geerlingguy.mysql/tasks/setup-Archlinux.yml
@@ -1,0 +1,12 @@
+---
+- name: Ensure MySQL Python libraries are installed.
+  pacman: "name=mysql-python state=present"
+
+- name: Ensure MySQL packages are installed.
+  pacman: "name={{ item }} state=present"
+  with_items: "{{ mysql_packages }}"
+  register: arch_mysql_install_packages
+
+# Init the database if mysql is newly installed
+- command: mysql_install_db --user=mysql --basedir=/usr --datadir=/var/lib/mysql
+  when: arch_mysql_install_packages.changed

--- a/roles/geerlingguy.mysql/tasks/setup-Debian.yml
+++ b/roles/geerlingguy.mysql/tasks/setup-Debian.yml
@@ -1,0 +1,29 @@
+---
+- name: Check if MySQL is already installed.
+  stat: path=/etc/init.d/mysql
+  register: mysql_installed
+
+- name: Update apt cache if MySQL is not yet installed.
+  apt: update_cache=yes
+  when: mysql_installed.stat.exists == false
+
+- name: Ensure MySQL Python libraries are installed.
+  apt: "name=python-mysqldb state=installed"
+
+- name: Ensure MySQL packages are installed.
+  apt: "name={{ item }} state=installed"
+  with_items: "{{ mysql_packages }}"
+  register: deb_mysql_install_packages
+
+# Because Ubuntu starts MySQL as part of the install process, we need to stop
+# mysql and remove the logfiles in case the user set a custom log file size.
+- name: Ensure MySQL is stopped after initial install.
+  service: "name={{ mysql_daemon }} state=stopped"
+  when: mysql_installed.stat.exists == false
+
+- name: Delete innodb log files created by apt package after initial install.
+  file: path={{ mysql_datadir }}/{{item}} state=absent
+  with_items:
+          - "ib_logfile0"
+          - "ib_logfile1"
+  when: mysql_installed.stat.exists == false

--- a/roles/geerlingguy.mysql/tasks/setup-RedHat.yml
+++ b/roles/geerlingguy.mysql/tasks/setup-RedHat.yml
@@ -1,0 +1,8 @@
+---
+- name: Ensure MySQL packages are installed.
+  yum: "name={{ item }} state=installed enablerepo={{ mysql_enablerepo }}"
+  with_items: "{{ mysql_packages }}"
+  register: rh_mysql_install_packages
+
+- name: Ensure MySQL Python libraries are installed.
+  yum: "name=MySQL-python state=installed enablerepo={{ mysql_enablerepo }}"

--- a/roles/geerlingguy.mysql/tasks/users.yml
+++ b/roles/geerlingguy.mysql/tasks/users.yml
@@ -1,0 +1,12 @@
+---
+- name: Ensure MySQL users are present.
+  mysql_user:
+    name: "{{ item.name }}"
+    host: "{{ item.host | default('localhost') }}"
+    password: "{{ item.password }}"
+    priv: "{{ item.priv | default('*.*:USAGE') }}"
+    state: "{{ item.state | default('present') }}"
+    append_privs: "{{ item.append_privs | default('no') }}"
+    encrypted: "{{ item.encrypted | default('no') }}"
+  with_items: "{{ mysql_users }}"
+  no_log: true

--- a/roles/geerlingguy.mysql/tasks/variables.yml
+++ b/roles/geerlingguy.mysql/tasks/variables.yml
@@ -1,0 +1,63 @@
+---
+# Variable configuration.
+- name: Include OS-specific variables.
+  include_vars: "{{ item }}"
+  with_first_found:
+    - files:
+      - "vars/{{ ansible_os_family }}.yml"
+      skip: true
+  when: ansible_os_family != "RedHat"
+
+- name: Include OS-specific variables (RedHat).
+  include_vars: "{{ ansible_os_family }}-{{ ansible_distribution_major_version }}.yml"
+  when: ansible_os_family == "RedHat"
+
+- name: Define mysql_packages.
+  set_fact:
+    mysql_packages: "{{ __mysql_packages | list }}"
+  when: mysql_packages is not defined
+
+- name: Define mysql_daemon.
+  set_fact:
+    mysql_daemon: "{{ __mysql_daemon }}"
+  when: mysql_daemon is not defined
+
+- name: Define mysql_slow_query_log_file.
+  set_fact:
+    mysql_slow_query_log_file: "{{ __mysql_slow_query_log_file }}"
+  when: mysql_slow_query_log_file is not defined
+
+- name: Define mysql_log_error.
+  set_fact:
+    mysql_log_error: "{{ __mysql_log_error }}"
+  when: mysql_log_error is not defined
+
+- name: Define mysql_syslog_tag.
+  set_fact:
+    mysql_syslog_tag: "{{ __mysql_syslog_tag }}"
+  when: mysql_syslog_tag is not defined
+
+- name: Define mysql_pid_file.
+  set_fact:
+    mysql_pid_file: "{{ __mysql_pid_file }}"
+  when: mysql_pid_file is not defined
+
+- name: Define mysql_config_file.
+  set_fact:
+    mysql_config_file: "{{ __mysql_config_file }}"
+  when: mysql_config_file is not defined
+
+- name: Define mysql_config_include_dir.
+  set_fact:
+    mysql_config_include_dir: "{{ __mysql_config_include_dir }}"
+  when: mysql_config_include_dir is not defined
+
+- name: Define mysql_socket.
+  set_fact:
+    mysql_socket: "{{ __mysql_socket }}"
+  when: mysql_socket is not defined
+
+- name: Define mysql_supports_innodb_large_prefix.
+  set_fact:
+    mysql_supports_innodb_large_prefix: "{{ __mysql_supports_innodb_large_prefix }}"
+  when: mysql_supports_innodb_large_prefix is not defined

--- a/roles/geerlingguy.mysql/templates/my.cnf.j2
+++ b/roles/geerlingguy.mysql/templates/my.cnf.j2
@@ -1,0 +1,122 @@
+# {{ ansible_managed }}
+
+[client]
+#password = your_password
+port = {{ mysql_port }}
+socket = {{ mysql_socket }}
+
+[mysqld]
+port = {{ mysql_port }}
+bind-address = {{ mysql_bind_address }}
+datadir = {{ mysql_datadir }}
+socket = {{ mysql_socket }}
+pid-file = {{ mysql_pid_file }}
+{% if mysql_skip_name_resolve %}
+skip-name-resolve
+{% endif %}
+{% if mysql_sql_mode %}
+sql_mode = {{ mysql_sql_mode }}
+{% endif %}
+
+# Logging configuration.
+{% if mysql_log_error == 'syslog' or mysql_log == 'syslog' %}
+syslog
+syslog-tag = {{ mysql_syslog_tag }}
+{% else %}
+{% if mysql_log %}
+log = {{ mysql_log }}
+{% endif %}
+log-error = {{ mysql_log_error }}
+{% endif %}
+
+{% if mysql_slow_query_log_enabled %}
+# Slow query log configuration.
+slow_query_log = 1
+slow_query_log_file = {{ mysql_slow_query_log_file }}
+long_query_time = {{ mysql_slow_query_time }}
+{% endif %}
+
+{% if mysql_replication_master %}
+# Replication
+server-id = {{ mysql_server_id }}
+
+{% if mysql_replication_role == 'master' %}
+log_bin = mysql-bin
+log-bin-index = mysql-bin.index
+expire_logs_days = {{ mysql_expire_logs_days }}
+max_binlog_size = {{ mysql_max_binlog_size }}
+binlog_format = {{mysql_binlog_format}}
+
+{% for db in mysql_databases %}
+{% if db.replicate|default(1) %}
+binlog_do_db = {{ db.name }}
+{% else %}
+binlog_ignore_db = {{ db.name }}
+{% endif %}
+{% endfor %}
+{% endif %}
+
+{% if mysql_replication_role == 'slave' %}
+read_only
+relay-log = relay-bin
+relay-log-index = relay-bin.index
+{% endif %}
+{% endif %}
+
+# Disabling symbolic-links is recommended to prevent assorted security risks
+symbolic-links = 0
+
+# User is ignored when systemd is used (fedora >= 15).
+user = mysql
+
+# http://dev.mysql.com/doc/refman/5.5/en/performance-schema.html
+;performance_schema
+
+# Memory settings.
+key_buffer_size = {{ mysql_key_buffer_size }}
+max_allowed_packet = {{ mysql_max_allowed_packet }}
+table_open_cache = {{ mysql_table_open_cache }}
+sort_buffer_size = {{ mysql_sort_buffer_size }}
+read_buffer_size = {{ mysql_read_buffer_size }}
+read_rnd_buffer_size = {{ mysql_read_rnd_buffer_size }}
+myisam_sort_buffer_size = {{ mysql_myisam_sort_buffer_size }}
+thread_cache_size = {{ mysql_thread_cache_size }}
+query_cache_type = {{ mysql_query_cache_type }}
+query_cache_size = {{ mysql_query_cache_size }}
+query_cache_limit = {{ mysql_query_cache_limit }}
+max_connections = {{ mysql_max_connections }}
+tmp_table_size = {{ mysql_tmp_table_size }}
+max_heap_table_size = {{ mysql_max_heap_table_size }}
+group_concat_max_len = {{ mysql_group_concat_max_len }}
+join_buffer_size = {{ mysql_join_buffer_size }}
+
+# Other settings.
+wait_timeout = {{ mysql_wait_timeout }}
+lower_case_table_names = {{ mysql_lower_case_table_names }}
+event_scheduler = {{ mysql_event_scheduler_state }}
+
+# InnoDB settings.
+{% if mysql_supports_innodb_large_prefix %}
+innodb_large_prefix = {{ mysql_innodb_large_prefix }}
+innodb_file_format = {{ mysql_innodb_file_format }}
+{% endif %}
+innodb_file_per_table = {{ mysql_innodb_file_per_table }}
+innodb_buffer_pool_size = {{ mysql_innodb_buffer_pool_size }}
+innodb_log_file_size = {{ mysql_innodb_log_file_size }}
+innodb_log_buffer_size = {{ mysql_innodb_log_buffer_size }}
+innodb_flush_log_at_trx_commit = {{ mysql_innodb_flush_log_at_trx_commit }}
+innodb_lock_wait_timeout = {{ mysql_innodb_lock_wait_timeout }}
+
+[mysqldump]
+quick
+max_allowed_packet = {{ mysql_mysqldump_max_allowed_packet }}
+
+[mysqld_safe]
+pid-file = {{ mysql_pid_file }}
+
+{% if mysql_config_include_files | length %}
+# * IMPORTANT: Additional settings that can override those from this file!
+#   The files must end with '.cnf', otherwise they'll be ignored.
+#
+!includedir {{ mysql_config_include_dir }}
+{% endif %}

--- a/roles/geerlingguy.mysql/templates/root-my.cnf.j2
+++ b/roles/geerlingguy.mysql/templates/root-my.cnf.j2
@@ -1,0 +1,5 @@
+# {{ ansible_managed }}
+
+[client]
+user="{{ mysql_root_username }}"
+password="{{ mysql_root_password }}"

--- a/roles/geerlingguy.mysql/templates/user-my.cnf.j2
+++ b/roles/geerlingguy.mysql/templates/user-my.cnf.j2
@@ -1,0 +1,5 @@
+# {{ ansible_managed }}
+
+[client]
+user="{{ mysql_user_name }}"
+password="{{ mysql_user_password }}"

--- a/roles/geerlingguy.mysql/tests/README.md
+++ b/roles/geerlingguy.mysql/tests/README.md
@@ -1,0 +1,11 @@
+# Ansible Role tests
+
+To run the test playbook(s) in this directory:
+
+  1. Install and start Docker.
+  1. Download the test shim (see .travis.yml file for the URL) into `tests/test.sh`:
+    - `wget -O tests/test.sh https://gist.githubusercontent.com/geerlingguy/73ef1e5ee45d8694570f334be385e181/raw/`
+  1. Make the test shim executable: `chmod +x tests/test.sh`.
+  1. Run (from the role root directory) `distro=[distro] playbook=[playbook] ./tests/test.sh`
+
+If you don't want the container to be automatically deleted after the test playbook is run, add the following environment variables: `cleanup=false container_id=$(date +%s)`

--- a/roles/geerlingguy.mysql/tests/centos-7-test.yml
+++ b/roles/geerlingguy.mysql/tests/centos-7-test.yml
@@ -1,0 +1,15 @@
+---
+- hosts: all
+  vars:
+    mysql_packages:
+      - mariadb
+      - mariadb-server
+      - mariadb-libs
+      - MySQL-python
+      - perl-DBD-MySQL
+    mysql_daemon: mariadb
+    mysql_log_error: /var/log/mariadb/mariadb.log
+    mysql_syslog_tag: mariadb
+    mysql_pid_file: /var/run/mariadb/mariadb.pid
+  roles:
+    - role_under_test

--- a/roles/geerlingguy.mysql/tests/initctl_faker
+++ b/roles/geerlingguy.mysql/tests/initctl_faker
@@ -1,0 +1,23 @@
+#!/bin/sh
+ALIAS_CMD="$(echo ""$0"" | sed -e 's?/sbin/??')"
+
+case "$ALIAS_CMD" in
+    start|stop|restart|reload|status)
+        exec service $1 $ALIAS_CMD
+        ;;
+esac
+
+case "$1" in
+    list )
+        exec service --status-all
+        ;;
+    reload-configuration )
+        exec service $2 restart
+        ;;
+    start|stop|restart|reload|status)
+        exec service $2 $1
+        ;;
+    \?)
+        exit 0
+        ;;
+esac

--- a/roles/geerlingguy.mysql/tests/test.yml
+++ b/roles/geerlingguy.mysql/tests/test.yml
@@ -1,0 +1,15 @@
+---
+- hosts: all
+
+  pre_tasks:
+    - name: Copy initctl_faker into place for Ubuntu 14.04.
+      copy:
+        src: initctl_faker
+        dest: /sbin/initctl
+        mode: 0755
+        force: yes
+      when: ansible_distribution == 'Ubuntu' and ansible_distribution_version == '14.04'
+      changed_when: false
+
+  roles:
+    - role_under_test

--- a/roles/geerlingguy.mysql/vars/Archlinux.yml
+++ b/roles/geerlingguy.mysql/vars/Archlinux.yml
@@ -1,0 +1,12 @@
+---
+__mysql_daemon: mariadb
+__mysql_packages:
+  - mariadb
+__mysql_slow_query_log_file: /var/log/mysql/mysql-slow.log
+__mysql_log_error: /var/log/mysql.err
+__mysql_syslog_tag: mysql
+__mysql_pid_file: /run/mysqld/mysqld.pid
+__mysql_config_file: /etc/mysql/my.cnf
+__mysql_config_include_dir: /etc/mysql/conf.d
+__mysql_socket: /run/mysqld/mysqld.sock
+__mysql_supports_innodb_large_prefix: true

--- a/roles/geerlingguy.mysql/vars/Debian.yml
+++ b/roles/geerlingguy.mysql/vars/Debian.yml
@@ -1,0 +1,13 @@
+---
+__mysql_daemon: mysql
+__mysql_packages:
+  - mysql-common
+  - mysql-server
+__mysql_slow_query_log_file: /var/log/mysql/mysql-slow.log
+__mysql_log_error: /var/log/mysql/mysql.err
+__mysql_syslog_tag: mysql
+__mysql_pid_file: /var/run/mysqld/mysqld.pid
+__mysql_config_file: /etc/mysql/my.cnf
+__mysql_config_include_dir: /etc/mysql/conf.d
+__mysql_socket: /var/run/mysqld/mysqld.sock
+__mysql_supports_innodb_large_prefix: true

--- a/roles/geerlingguy.mysql/vars/RedHat-6.yml
+++ b/roles/geerlingguy.mysql/vars/RedHat-6.yml
@@ -1,0 +1,13 @@
+---
+__mysql_daemon: mysqld
+__mysql_packages:
+  - mysql
+  - mysql-server
+__mysql_slow_query_log_file: /var/log/mysql-slow.log
+__mysql_log_error: /var/log/mysql.err
+__mysql_syslog_tag: mysql
+__mysql_pid_file: /var/run/mysqld/mysqld.pid
+__mysql_config_file: /etc/my.cnf
+__mysql_config_include_dir: /etc/my.cnf.d
+__mysql_socket: /var/lib/mysql/mysql.sock
+__mysql_supports_innodb_large_prefix: false

--- a/roles/geerlingguy.mysql/vars/RedHat-7.yml
+++ b/roles/geerlingguy.mysql/vars/RedHat-7.yml
@@ -1,0 +1,16 @@
+---
+__mysql_daemon: mariadb
+__mysql_packages:
+  - mariadb
+  - mariadb-server
+  - mariadb-libs
+  - MySQL-python
+  - perl-DBD-MySQL
+__mysql_slow_query_log_file: /var/log/mysql-slow.log
+__mysql_log_error: /var/log/mariadb/mariadb.log
+__mysql_syslog_tag: mariadb
+__mysql_pid_file: /var/run/mariadb/mariadb.pid
+__mysql_config_file: /etc/my.cnf
+__mysql_config_include_dir: /etc/my.cnf.d
+__mysql_socket: /var/lib/mysql/mysql.sock
+__mysql_supports_innodb_large_prefix: true


### PR DESCRIPTION
fixes #4

This just adds sql with default username/password as root/root and no databases, so very bare bones and completely insecure/useless.

Testing:
- run `vagrant up` or `vagrant provision`
- run `vagrant ssh -c "mysql -u root -p root"`
- this should allow running sql queries, test e.g. `show databases;`