### PR TITLE
npm install for bot in vagrant

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .vagrant
 playbook.retry
+node_modules

--- a/README.md
+++ b/README.md
@@ -41,13 +41,6 @@ This will download to the roles directory shared between the vagrant guest and t
 
 This chatbot helps to run "Bounce Back Lottery".
 
-## Install
-
-Install node.js, clone the repository, then say
-```sh
-npm install
-```
-
 ## Run
 ```sh
 node toto.js 2>errlog

--- a/playbook.yml
+++ b/playbook.yml
@@ -3,6 +3,13 @@
   hosts: all
   remote_user: root
   become: true
+
   roles:
+    - geerlingguy.git
     - geerlingguy.nodejs
     - geerlingguy.mysql
+
+  tasks:
+    - name: install node packages for bot
+      npm:
+        path: /vagrant

--- a/roles/geerlingguy.git/.gitignore
+++ b/roles/geerlingguy.git/.gitignore
@@ -1,0 +1,2 @@
+*.retry
+tests/test.sh

--- a/roles/geerlingguy.git/.travis.yml
+++ b/roles/geerlingguy.git/.travis.yml
@@ -1,0 +1,59 @@
+---
+services: docker
+
+env:
+  # Test source install on latest supported OSes.
+  - distro: centos7
+    playbook: test-source.yml
+    GIT_VERSION: 2.9.3
+  - distro: fedora24
+    playbook: test-source.yml
+    GIT_VERSION: 2.9.3
+  - distro: ubuntu1604
+    playbook: test-source.yml
+    GIT_VERSION: 2.9.3
+
+  # Test package install on all supported OSes.
+  - distro: centos7
+    playbook: test.yml
+    GIT_VERSION: 1.8.3.1
+  - distro: centos6
+    playbook: test.yml
+    GIT_VERSION: 1.7.1
+  - distro: fedora24
+    playbook: test.yml
+    GIT_VERSION: 2.7.5
+  - distro: ubuntu1604
+    playbook: test.yml
+    GIT_VERSION: 2.7.4
+  - distro: ubuntu1404
+    playbook: test.yml
+    GIT_VERSION: 1.9.1
+  - distro: ubuntu1204
+    playbook: test.yml
+    GIT_VERSION: 1.7.9.5
+  - distro: debian8
+    playbook: test.yml
+    GIT_VERSION: 2.1.4
+
+script:
+  # Configure test script so we can run extra tests after playbook is run.
+  - export container_id=$(date +%s)
+  - export cleanup=false
+
+  # Download test shim.
+  - wget -O ${PWD}/tests/test.sh https://gist.githubusercontent.com/geerlingguy/73ef1e5ee45d8694570f334be385e181/raw/
+  - chmod +x ${PWD}/tests/test.sh
+
+  # Run tests.
+  - ${PWD}/tests/test.sh
+
+  # Ensure Git is installed and at the right version.
+  - 'docker exec --tty ${container_id} env TERM=xterm which git'
+  - 'docker exec --tty ${container_id} env TERM=xterm test -x /usr/bin/git'
+
+  - 'docker exec --tty ${container_id} env TERM=xterm git --version'
+  - 'docker exec --tty ${container_id} env TERM=xterm /usr/bin/git --version | grep -qF "$GIT_VERSION"'
+
+notifications:
+  webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/roles/geerlingguy.git/LICENSE
+++ b/roles/geerlingguy.git/LICENSE
@@ -1,0 +1,20 @@
+The MIT License (MIT)
+
+Copyright (c) 2017 Jeff Geerling
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/roles/geerlingguy.git/README.md
+++ b/roles/geerlingguy.git/README.md
@@ -1,0 +1,55 @@
+# Ansible Role: Git
+
+[![Build Status](https://travis-ci.org/geerlingguy/ansible-role-git.svg?branch=master)](https://travis-ci.org/geerlingguy/ansible-role-git)
+
+Installs Git, a distributed version control system, on any RHEL/CentOS or Debian/Ubuntu Linux system.
+
+## Requirements
+
+None.
+
+## Role Variables
+
+Available variables are listed below, along with default values (see `defaults/main.yml`):
+
+    workspace: /root
+
+Where certain files will be downloaded and adjusted prior to git installation, if needed.
+
+    git_enablerepo: ""
+
+This variable, a well as `git_packages`, will be used to install git via a particular `yum` repo if `git_install_from_source` is false (CentOS only). Any additional repositories you have installed that you would like to use for a newer/different Git version.
+
+    git_packages:
+      - git
+      - git-svn
+
+The specific Git packages that will be installed. By default, `git-svn` is included, but you can easily add this variable to your playbook's variables and remove `git-svn` if desired.
+
+    git_install_from_source: false
+    git_install_path: "/usr"
+    git_version: "2.1.0"
+
+Whether to install Git from source; if set to `true`, `git_version` is required and will be used to install a particular version of git (see all available versions here: https://www.kernel.org/pub/software/scm/git/), and `git_install_path` defines where git should be installed.
+
+    git_install_from_source_force_update: false
+
+If git is already installed at and older version, force a new source build. Only applies if `git_install_from_source` is `true`.
+
+## Dependencies
+
+None.
+
+## Example Playbook
+
+    - hosts: servers
+      roles:
+        - { role: geerlingguy.git }
+
+## License
+
+MIT / BSD
+
+## Author Information
+
+This role was created in 2014 by [Jeff Geerling](https://www.jeffgeerling.com/), author of [Ansible for DevOps](https://www.ansiblefordevops.com/).

--- a/roles/geerlingguy.git/defaults/main.yml
+++ b/roles/geerlingguy.git/defaults/main.yml
@@ -1,0 +1,23 @@
+---
+workspace: /root
+
+# If git_install_from_source is set to false, these two variables define whether
+# to use an additional repo for the package installation, and which git packages
+# will be installed.
+git_enablerepo: ""
+git_packages:
+  - git
+  - git-svn
+
+# If set to TRUE, git will be installed from source, using the version set with
+# the 'git_version' variable instead of using a package.
+git_install_from_source: false
+git_install_path: "/usr"
+git_version: "2.9.3"
+
+# If git is already installed at and older version, force a new source build.
+# Only applies if git_install_from_source is `true`.
+git_install_from_source_force_update: false
+
+# Leave this at it's default.
+git_reinstall_from_source: false

--- a/roles/geerlingguy.git/meta/.galaxy_install_info
+++ b/roles/geerlingguy.git/meta/.galaxy_install_info
@@ -1,0 +1,1 @@
+{install_date: 'Wed Oct  4 21:42:14 2017', version: 1.4.0}

--- a/roles/geerlingguy.git/meta/main.yml
+++ b/roles/geerlingguy.git/meta/main.yml
@@ -1,0 +1,25 @@
+---
+dependencies: []
+
+galaxy_info:
+  author: geerlingguy
+  description: Git version control software
+  company: "Midwestern Mac, LLC"
+  license: "license (BSD, MIT)"
+  min_ansible_version: 2.2
+  platforms:
+  - name: EL
+    versions:
+    - all
+  - name: Fedora
+    versions:
+    - all
+  - name: Debian
+    versions:
+    - all
+  - name: Ubuntu
+    versions:
+    - all
+  galaxy_tags:
+    - development
+    - system

--- a/roles/geerlingguy.git/tasks/install-from-source.yml
+++ b/roles/geerlingguy.git/tasks/install-from-source.yml
@@ -1,0 +1,70 @@
+---
+
+- name: Include OS-specific variables (RedHat).
+  include_vars: "{{ ansible_os_family }}.yml"
+  when:
+    - ansible_os_family == "RedHat"
+    - ansible_distribution != "Fedora"
+
+- name: Include OS-specific variables (Fedora).
+  include_vars: "{{ ansible_distribution }}.yml"
+  when: ansible_distribution == "Fedora"
+
+- name: Include OS-specific variables (Debian).
+  include_vars: "{{ ansible_os_family }}.yml"
+  when: ansible_os_family == "Debian"
+
+- name: Define git_install_from_source_dependencies.
+  set_fact:
+    git_install_from_source_dependencies: "{{ __git_install_from_source_dependencies | list }}"
+  when: git_install_from_source_dependencies is not defined
+
+- name: Ensure git's dependencies are installed (RedHat).
+  package: "name={{ item }} state=installed"
+  with_items: "{{ git_install_from_source_dependencies }}"
+  when: ansible_os_family == 'RedHat'
+
+- name: Ensure git's dependencies are installed (Debian).
+  apt: "name={{ item }} state=installed"
+  with_items: "{{ git_install_from_source_dependencies }}"
+  when: ansible_os_family == 'Debian'
+
+- name: Get installed version
+  command: >
+    git --version
+    warn=no
+  changed_when: false
+  failed_when: false
+  check_mode: no
+  register: git_installed_version
+
+- name: Force git install if the version numbers do not match
+  set_fact:
+    git_reinstall_from_source: true
+  when:
+    - git_install_from_source_force_update
+    - git_installed_version|success and (git_installed_version.stdout | regex_replace("^.*?([0-9\.]+)$", "\\1") | version_compare(git_version, operator="!="))
+
+- name: Download git.
+  get_url:
+    url: "https://www.kernel.org/pub/software/scm/git/git-{{ git_version }}.tar.gz"
+    dest: "{{ workspace }}/git-{{ git_version }}.tar.gz"
+  when:  git_installed_version|failed or git_reinstall_from_source
+
+- name: Expand git archive.
+  unarchive:
+    src: "{{ workspace }}/git-{{ git_version }}.tar.gz"
+    dest: "{{ workspace }}"
+    creates: "{{ workspace }}/git-{{ git_version }}/README"
+    copy: no
+  when:  git_installed_version|failed or git_reinstall_from_source
+
+- name: Build git.
+  command: >
+    make prefix={{ git_install_path }} {{ item }}
+    chdir={{ workspace }}/git-{{ git_version }}
+  with_items:
+    - all
+    - install
+  when:  git_installed_version|failed or git_reinstall_from_source
+  become: yes

--- a/roles/geerlingguy.git/tasks/main.yml
+++ b/roles/geerlingguy.git/tasks/main.yml
@@ -1,0 +1,23 @@
+---
+- name: Ensure git is installed (RedHat).
+  package:
+    name: "{{ item }}"
+    state: installed
+    enablerepo: "{{ git_enablerepo }}"
+  with_items: "{{ git_packages }}"
+  when: (git_install_from_source == false) and (ansible_os_family == 'RedHat')
+
+- name: Update apt cache (Debian).
+  apt: update_cache=yes cache_valid_time=86400
+  when: ansible_os_family == 'Debian'
+
+- name: Ensure git is installed (Debian).
+  apt:
+    name: "{{ item }}"
+    state: installed
+  with_items: "{{ git_packages }}"
+  when: (git_install_from_source == false) and (ansible_os_family == 'Debian')
+
+# Install git from source when git_install_from_source is true.
+- include: install-from-source.yml
+  when: git_install_from_source == true

--- a/roles/geerlingguy.git/tests/README.md
+++ b/roles/geerlingguy.git/tests/README.md
@@ -1,0 +1,11 @@
+# Ansible Role tests
+
+To run the test playbook(s) in this directory:
+
+  1. Install and start Docker.
+  1. Download the test shim (see .travis.yml file for the URL) into `tests/test.sh`:
+    - `wget -O tests/test.sh https://gist.githubusercontent.com/geerlingguy/73ef1e5ee45d8694570f334be385e181/raw/`
+  1. Make the test shim executable: `chmod +x tests/test.sh`.
+  1. Run (from the role root directory) `distro=[distro] playbook=[playbook] ./tests/test.sh`
+
+If you don't want the container to be automatically deleted after the test playbook is run, add the following environment variables: `cleanup=false container_id=$(date +%s)`

--- a/roles/geerlingguy.git/tests/test-source.yml
+++ b/roles/geerlingguy.git/tests/test-source.yml
@@ -1,0 +1,16 @@
+---
+- hosts: all
+
+  vars:
+    git_install_from_source: true
+    git_install_from_source_force_update: true
+    git_version: 2.9.3
+
+  pre_tasks:
+    - name: Update apt cache.
+      apt: update_cache=yes cache_valid_time=600
+      when: ansible_os_family == 'Debian'
+      changed_when: false
+
+  roles:
+    - role_under_test

--- a/roles/geerlingguy.git/tests/test.yml
+++ b/roles/geerlingguy.git/tests/test.yml
@@ -1,0 +1,15 @@
+---
+- hosts: all
+
+  vars:
+    git_install_from_source: false
+    git_install_path: /usr/local
+
+  pre_tasks:
+    - name: Update apt cache.
+      apt: update_cache=yes cache_valid_time=600
+      when: ansible_os_family == 'Debian'
+      changed_when: false
+
+  roles:
+    - role_under_test

--- a/roles/geerlingguy.git/vars/Debian.yml
+++ b/roles/geerlingguy.git/vars/Debian.yml
@@ -1,0 +1,9 @@
+---
+git_install_from_source_dependencies:
+  - libcurl4-gnutls-dev
+  - libexpat1-dev
+  - gettext
+  - libssl-dev
+  - build-essential
+  - gcc
+

--- a/roles/geerlingguy.git/vars/Fedora.yml
+++ b/roles/geerlingguy.git/vars/Fedora.yml
@@ -1,0 +1,13 @@
+---
+git_install_from_source_dependencies:
+  - gettext-devel
+  - expat-devel
+  - curl-devel
+  - zlib-devel
+  - perl-devel
+  - openssl-devel
+  - subversion-perl
+  - make
+  - gcc
+  - tar
+

--- a/roles/geerlingguy.git/vars/RedHat.yml
+++ b/roles/geerlingguy.git/vars/RedHat.yml
@@ -1,0 +1,12 @@
+---
+git_install_from_source_dependencies:
+  - gettext-devel
+  - expat-devel
+  - curl-devel
+  - zlib-devel
+  - perl-devel
+  - openssl-devel
+  - subversion-perl
+  - make
+  - gcc
+

--- a/roles/geerlingguy.git/vars/main.yml
+++ b/roles/geerlingguy.git/vars/main.yml
@@ -1,0 +1,3 @@
+---
+# This space intentionally left blank.
+


### PR DESCRIPTION
fixes #17 

testing:
- run `vagrant provision`
- run `vagrant ssh -c "ls /vagrant/node_modules"`
- should see installed node modules for the bot